### PR TITLE
Use min parameter in arrays as well as objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function normalizeToRange(array, min, max, field)
 
     // Array of numbers
     else {
-      x = x / divisor;
+      x = Math.max(x / divisor, min);
     }
 
     return x;

--- a/test/number.js
+++ b/test/number.js
@@ -2,10 +2,13 @@ var test = require('tape');
 var normalize = require('../index.js');
 
 test('Array of numbers', function(t) {
-  t.plan(1);
+  t.plan(2);
 
   var array = [5, 10, 15, 20, 25, 30, 35, 40];
   t.deepEquals(normalize(array, 0, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
+
+  array = [0, 50, 100];
+  t.deepEquals(normalize(array, 100, 1000), [100, 500, 1000]);
 });
 
 test('Default params', function(t) {

--- a/test/object.js
+++ b/test/object.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var normalize = require('../index.js');
 
 test('Array of objects', function(t) {
-  t.plan(2);
+  t.plan(3);
 
   var array = [
     { color: 'green', height: 2000 },
@@ -31,6 +31,20 @@ test('Array of objects', function(t) {
   ];
 
   t.deepEquals(normalize(array, 0, 10, 'height'), shouldEqual);
+
+  array = [
+    { color: 'green', height: 0 },
+    { color: 'red', height: 50 },
+    { color: 'purple', height: 100 }
+  ];
+
+  shouldEqual = [
+    { color: 'green', height: 100 },
+    { color: 'red', height: 500 },
+    { color: 'purple', height: 1000 }
+  ];
+
+  t.deepEquals(normalize(array, 100, 1000, 'height'), shouldEqual);
 });
 
 test('Throw on empty array', function(t) {


### PR DESCRIPTION
The 'min' parameter was only being used when an array of objects was passed in.
I've changed this to work on a normal array of numbers too.

I'm not sure if this should work this way, using the 'min' as the lowest value, or if the numbers should be normalized within that range.

eg. `normalize([0, 5, 10], 100, 1000)` returns `[100, 500, 1000]`
should it return `[100, 550, 1000]` instead?
